### PR TITLE
Add mhchem for writing chemical equations

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ for rendering output.
 'use strict';
 
 var katex = require('katex');
+require('katex/contrib/mhchem');
 
 // Test if potential opening or closing delimieter
 // Assumes that there is a "$" at state.src[pos]


### PR DESCRIPTION
The [mhchem extension](https://mhchem.github.io/MathJax-mhchem/) adds its features by modifying the katex module. So you can use KaTeX with mhchem in Node.